### PR TITLE
Load @import references relative to original file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Just configure webpack to handle nearley files with this loader:
 ```javascript
 module: {
   loaders: [
-    { test: /\.ne$/, loader: 'nearley' }
+    { test: /\.ne$/, loader: 'nearley-loader' }
   ]
 }
 ```

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function(input) {
   var parser = new nearley.Parser(grammar.ParserRules, grammar.ParserStart);
   parser.feed(input);
 
-  var compilation = compile(parser.results[0], {});
+  var compilation = compile(parser.results[0], { file: this.resourcePath });
   return generate(compilation, 'Grammar');
 }
 


### PR DESCRIPTION
Addressing the issue #3 
Passing the file path in compiler options
Fixed the documentation with correct loader name