### PR TITLE
Specify `-loader` suffix in docs for webpack 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Just configure webpack to handle nearley files with this loader:
 ```javascript
 module: {
   loaders: [
-    { test: /\.ne$/, loader: 'nearley' }
+    { test: /\.ne$/, loader: 'nearley-loader' }
   ]
 }
 ```


### PR DESCRIPTION
See https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed