### PR TITLE
Recompile when @include-ed file changed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,11 +6,19 @@ var rawGrammar = require('nearley/lib/nearley-language-bootstrapped.js');
 
 var nearleyGrammar = nearley.Grammar.fromCompiled(rawGrammar);
 
-module.exports = function(input) {
+module.exports = function (input) {
   var parser = new nearley.Parser(nearleyGrammar);
   parser.feed(input);
-  var compilation = compile(parser.results[0], {file: this.resourcePath});
+  const opts = {
+    args: [this.resourcePath],
+    alreadycompiled: [],
+  }
+  var compilation = compile(parser.results[0], opts);
+  // add dependencies of used @include statements
+  for (const dep of opts.alreadycompiled) {
+    this.addDependency(dep);
+  }
   lint(compilation, {});
-  return generate(compilation, 'grammar');
+  const ret = generate(compilation, 'grammar');
+  return ret;
 }
-


### PR DESCRIPTION
When using watch mode, included files (using @include statement) are not triggering webpack rebuild when changed.
This fixes it.